### PR TITLE
Contract renewal保存失敗によるバグの解消

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -2,7 +2,10 @@ class Subscription < ApplicationRecord
   # バリデーション
   with_options presence: true do
     validates :name, length: { maximum: 10 }
-    validates :price, numericality: { only_integer: true }
+    validates :price, numericality: {
+      only_integer: true,
+      greater_than_or_equal_to: 0
+    }
     validates :contract_date
     validates :update_cycle, numericality: {
       only_integer: true,

--- a/app/views/subscriptions/new.html.erb
+++ b/app/views/subscriptions/new.html.erb
@@ -1,5 +1,5 @@
 <div class="bg-gray-100 py-8">
-  <%= form_with model: [@user, @subs], url: user_subscriptions_path(@user), class:"w-full", local: true do |f| %>
+  <%= form_with model: [@user, @subs], url: user_subscriptions_path(@user), method: :POST, class:"w-full", local: true do |f| %>
     <div class="container px-5 py-6 mx-auto my-8 flex flex-col items-center lg:w-2/4 md:w-2/4 sm:w-96 bg-white rounded-lg">
       <h2 class="text-gray-900 text-2xl font-bold title-font my-5">サブスク登録</h2>
 

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -20,6 +20,11 @@ RSpec.describe Subscription, type: :model do
       expect(@subs).to be_valid
     end
 
+    it 'priceが0以上なら登録できる' do
+      @subs.price = 0
+      expect(@subs).to be_valid
+    end
+
     it 'update_cycleが1~31の数値なら登録できる' do
       @subs.update_cycle = 25
       expect(@subs).to be_valid
@@ -126,6 +131,12 @@ RSpec.describe Subscription, type: :model do
       @subs.price = 'e'
       @subs.valid?
       expect(@subs.errors.full_messages).to include('価格は数値で入力してください')
+    end
+
+    it 'priceが0未満の数値では登録できない' do
+      @subs.price = -1
+      @subs.valid?
+      expect(@subs.errors.full_messages).to include('価格は0以上の値にしてください')
     end
 
     it 'update_type_idが数値以外では登録できない' do


### PR DESCRIPTION
# What

- Subscriptionモデルのpriceに「0以上」であるバリデーションを追加
- form_withの引数にmethodも指定し、インスタンスの状態に関わらずHTTPメソッドがPOSTになるように設定。
- ContractRenewalモデルのsaveに失敗した際、Subscriptionモデルのsaveが差し戻されうようにtransactionを実装。

# Why
サブスク登録時における、下記問題を解消するため
- Subscriptionモデルのpriceがマイナスでも登録できてしまう
- render後のフォーム再送で、HTTPメソッドがPATCHになる
- Subscriptionモデルのsaveに成功するが、ContractRenewalモデルのsaveに失敗した際、Subscriptionモデルが保存されてしまう。

